### PR TITLE
fix typo in SHA256 comment

### DIFF
--- a/src/hash/sha256_u4.rs
+++ b/src/hash/sha256_u4.rs
@@ -312,7 +312,7 @@ pub fn sha256(num_bytes: u32) -> Script {
 
             if c > 0 {
                 //change and with xor
-                //TODO: if lookup table is pushed first and substracted
+                //TODO: if lookup table is pushed first and subtracted
                 // then we could avoid changing it  ~(32 * chunk)
                 { u4_drop_half_lookup() }
                 { u4_drop_half_and() }


### PR DESCRIPTION


## Description

**Minor fix**: Corrected a typo in the comment within `sha256_u4.rs`

### Changes
- **File**: `src/hash/sha256_u4.rs`
- **Line**: 315
- **Fix**: `substracted` → `subtracted`

